### PR TITLE
digging into |ref| inside lists in stack configuration

### DIFF
--- a/src/main/python/cfn_sphere/stack_configuration/dependency_resolver.py
+++ b/src/main/python/cfn_sphere/stack_configuration/dependency_resolver.py
@@ -45,7 +45,12 @@ class DependencyResolver(object):
         for name, data in desired_stacks.items():
             if data:
                 for _, value in data.parameters.items():
-                    if cls.is_parameter_reference(value):
+                    if isinstance(value, list):
+                        for item in value:
+                            if cls.is_parameter_reference(item):
+                                dependant_stack, _ = cls.parse_stack_reference_value(item)
+                                graph.add_edge(dependant_stack, name)
+                    elif cls.is_parameter_reference(value):
                         dependant_stack, _ = cls.parse_stack_reference_value(value)
                         graph.add_edge(dependant_stack, name)
 

--- a/src/main/python/cfn_sphere/stack_configuration/parameter_resolver.py
+++ b/src/main/python/cfn_sphere/stack_configuration/parameter_resolver.py
@@ -96,6 +96,11 @@ class ParameterResolver(object):
             if isinstance(value, list):
 
                 self.logger.debug("List parameter found for {0}".format(key))
+                for i, item in enumerate(value):
+                    if DependencyResolver.is_parameter_reference(item):
+                        referenced_stack, output_name = DependencyResolver.parse_stack_reference_value(item)
+                        value[i] = str(self.get_output_value(referenced_stack + '.' + output_name))
+
                 value_string = self.convert_list_to_string(value)
                 parameters[key] = value_string
 

--- a/src/unittest/python/stack_configuration/dependency_resolver_tests.py
+++ b/src/unittest/python/stack_configuration/dependency_resolver_tests.py
@@ -43,6 +43,22 @@ class DependencyResolverTests(unittest2.TestCase):
 
         self.assertEqual(expected, DependencyResolver.get_stack_order(stacks))
 
+    def test_get_stack_order_returns_a_valid_order_from_ref_in_list(self):
+        stacks = {'default-sg': StackConfig({'template-url': 'horst.yml', 'parameters': {'a': ['|Ref|vpc.id']}}),
+                  'app1': StackConfig(
+                      {'template-url': 'horst.yml', 'parameters': {'a': ['|Ref|vpc.id'], 'b': ['|Ref|default-sg.id']}}),
+                  'app2': StackConfig({'template-url': 'horst.yml',
+                                       'parameters': {'a': ['|Ref|vpc.id'], 'b': ['|Ref|default-sg.id'],
+                                                      'c': ['|Ref|app1.id']}}),
+                  'vpc': StackConfig({'template-url': 'horst.yml',
+                                      'parameters': {'logBucketName': 'is24-cloudtrail-logs',
+                                                     'includeGlobalServices': False}})
+                  }
+
+        expected = ['vpc', 'default-sg', 'app1', 'app2']
+
+        self.assertEqual(expected, DependencyResolver.get_stack_order(stacks))
+
     def test_get_stack_order_includes_independent_stacks(self):
         stacks = {'default-sg': StackConfig({'template-url': 'horst.yml'}),
                   'app1': StackConfig(

--- a/src/unittest/python/stack_configuration/parameter_resolver_tests.py
+++ b/src/unittest/python/stack_configuration/parameter_resolver_tests.py
@@ -26,6 +26,26 @@ class ParameterResolverTests(unittest2.TestCase):
         ParameterResolver().resolve_parameter_values({'foo': ['a', 'b']}, 'foo')
         convert_list_to_string_mock.assert_called_once_with(['a', 'b'])
 
+    @patch('cfn_sphere.stack_configuration.parameter_resolver.ParameterResolver.get_output_value')
+    @patch('cfn_sphere.stack_configuration.parameter_resolver.CloudFormation')
+    @patch('cfn_sphere.stack_configuration.parameter_resolver.Ec2Api')
+    @patch('cfn_sphere.stack_configuration.parameter_resolver.KMS')
+    def test_resolve_parameter_values_returns_ref_value(self, kms, ec2_api, cfn, get_output_value_mock):
+        get_output_value_mock.return_value = 'bar'
+        result = ParameterResolver().resolve_parameter_values({'foo': '|Ref|stack.output'}, 'foo')
+        get_output_value_mock.assert_called_once_with('stack.output')
+        self.assertEqual({'foo': 'bar'}, result)
+
+    @patch('cfn_sphere.stack_configuration.parameter_resolver.ParameterResolver.get_output_value')
+    @patch('cfn_sphere.stack_configuration.parameter_resolver.CloudFormation')
+    @patch('cfn_sphere.stack_configuration.parameter_resolver.Ec2Api')
+    @patch('cfn_sphere.stack_configuration.parameter_resolver.KMS')
+    def test_resolve_parameter_values_returns_ref_list_value(self, kms, ec2_api, cfn, get_output_value_mock):
+        get_output_value_mock.return_value = 'bar'
+        result = ParameterResolver().resolve_parameter_values({'foo': ['|Ref|stack.output', '|Ref|stack.output']}, 'foo')
+        get_output_value_mock.assert_called_with('stack.output')
+        self.assertEqual({'foo': 'bar,bar'}, result)
+
     @patch('cfn_sphere.stack_configuration.parameter_resolver.CloudFormation')
     @patch('cfn_sphere.stack_configuration.parameter_resolver.Ec2Api')
     @patch('cfn_sphere.stack_configuration.parameter_resolver.KMS')
@@ -131,3 +151,4 @@ class ParameterResolverTests(unittest2.TestCase):
 
         result = ParameterResolver().resolve_parameter_values({'foo': "|kms|encryptedValue"}, 'foo')
         self.assertEqual({'foo': 'decryptedValue'}, result)
+


### PR DESCRIPTION
wanted this to work in stack configuration:

foo:
- '|Ref|stack-one.bar'
- '|Ref|stack-two.bar'