### PR TITLE
decode response from kms to string

### DIFF
--- a/src/main/python/cfn_sphere/aws/kms.py
+++ b/src/main/python/cfn_sphere/aws/kms.py
@@ -25,4 +25,4 @@ class KMS(object):
         except BotoServerError as e:
             raise CfnSphereBotoError(e)
 
-        return response['Plaintext']
+        return response['Plaintext'].decode('utf-8')

--- a/src/unittest/python/aws/kms_tests.py
+++ b/src/unittest/python/aws/kms_tests.py
@@ -11,10 +11,18 @@ from cfn_sphere.exceptions import InvalidEncryptedValueException
 class KMSTests(unittest2.TestCase):
     @patch('cfn_sphere.aws.kms.kms.connect_to_region')
     def test_decrypt_value(self, kms_mock):
-        kms_mock.return_value.decrypt.return_value = {'Plaintext': bytes('decryptedValue', encoding='utf-8')}
+        kms_mock.return_value.decrypt.return_value = {'Plaintext': b'decryptedValue'}
 
         self.assertEqual('decryptedValue', KMS().decrypt("ZW5jcnlwdGVkVmFsdWU="))
         kms_mock.return_value.decrypt.assert_called_once_with(base64.b64decode("ZW5jcnlwdGVkVmFsdWU=".encode()))
+
+    @patch('cfn_sphere.aws.kms.kms.connect_to_region')
+    def test_decrypt_value_with_unicode_char(self, kms_mock):
+        kms_mock.return_value.decrypt.return_value = {'Plaintext': b'(\xe2\x95\xaf\xc2\xb0\xe2\x96\xa1\xc2\xb0\xef\xbc\x89\xe2\x95\xaf\xef\xb8\xb5 \xe2\x94\xbb\xe2\x94\x81\xe2\x94\xbb'}
+
+        self.assertEqual(u'(\u256f\xb0\u25a1\xb0\uff09\u256f\ufe35 \u253b\u2501\u253b', KMS().decrypt("KOKVr8Kw4pahwrDvvInila/vuLUg4pS74pSB4pS7"))
+        kms_mock.return_value.decrypt.assert_called_once_with(base64.b64decode("KOKVr8Kw4pahwrDvvInila/vuLUg4pS74pSB4pS7".encode()))
+
 
     @patch('cfn_sphere.aws.kms.kms.connect_to_region')
     def test_invalid_base64(self, kms_mock):

--- a/src/unittest/python/aws/kms_tests.py
+++ b/src/unittest/python/aws/kms_tests.py
@@ -2,15 +2,16 @@ import base64
 
 import unittest2
 from boto.kms.exceptions import InvalidCiphertextException
-from cfn_sphere.aws.kms import KMS
 from mock import patch
+
+from cfn_sphere.aws.kms import KMS
 from cfn_sphere.exceptions import InvalidEncryptedValueException
 
 
 class KMSTests(unittest2.TestCase):
     @patch('cfn_sphere.aws.kms.kms.connect_to_region')
     def test_decrypt_value(self, kms_mock):
-        kms_mock.return_value.decrypt.return_value = {'Plaintext': 'decryptedValue'}
+        kms_mock.return_value.decrypt.return_value = {'Plaintext': bytes('decryptedValue', encoding='utf-8')}
 
         self.assertEqual('decryptedValue', KMS().decrypt("ZW5jcnlwdGVkVmFsdWU="))
         kms_mock.return_value.decrypt.assert_called_once_with(base64.b64decode("ZW5jcnlwdGVkVmFsdWU=".encode()))


### PR DESCRIPTION
When getting a response from kms, the byte stream used to be returned directly which causes a string like b'mydata'. This pull requests decodes the response using an utf-8 char set to convert the response to a normal string before passing it further to its caller.