### PR TITLE
validate cli parameters for existing stacks

### DIFF
--- a/src/main/python/cfn_sphere/exceptions.py
+++ b/src/main/python/cfn_sphere/exceptions.py
@@ -3,7 +3,7 @@ from botocore.exceptions import ClientError
 
 class CfnSphereException(Exception):
     def __init__(self, message="", boto_exception=None):
-        self.pretty_string = message
+        self.pretty_string = str(message)
         self.str = self.pretty_string
         self.boto_exception = boto_exception
         self.request_id = None

--- a/src/main/python/cfn_sphere/stack_configuration/__init__.py
+++ b/src/main/python/cfn_sphere/stack_configuration/__init__.py
@@ -30,8 +30,10 @@ class Config(object):
             assert self.region, "Please specify region in config file"
             assert isinstance(self.region, str), "Region must be of type str, not {0}".format(type(self.region))
             assert self.stacks, "Please specify stacks in config file"
+            for cli_stack in self.cli_params.keys():
+                assert cli_stack in self.stacks.keys(), 'Stack "{0}" does not exist in config'.format(cli_stack)
         except AssertionError as e:
-            raise NoConfigException(e)
+            raise NoConfigException(e.message)
 
     def _parse_stack_configs(self, config_dict):
         """

--- a/src/main/python/cfn_sphere/stack_configuration/__init__.py
+++ b/src/main/python/cfn_sphere/stack_configuration/__init__.py
@@ -33,7 +33,7 @@ class Config(object):
             for cli_stack in self.cli_params.keys():
                 assert cli_stack in self.stacks.keys(), 'Stack "{0}" does not exist in config'.format(cli_stack)
         except AssertionError as e:
-            raise NoConfigException(e.message)
+            raise NoConfigException(e)
 
     def _parse_stack_configs(self, config_dict):
         """

--- a/src/unittest/python/stack_configuration/config_tests.py
+++ b/src/unittest/python/stack_configuration/config_tests.py
@@ -49,11 +49,16 @@ class ConfigTests(TestCase):
 
     def test_properties_parsing_cli_params(self):
         config = Config(cli_params=("stack1.p1=v1", "stack1.p2=v2"),
-                        config_dict={'region': 'eu-west-1', 'stacks': {'foo': {'template-url': 'foo.json'}}})
+                        config_dict={'region': 'eu-west-1', 'stacks': {'stack1': {'template-url': 'foo.json'}}})
         self.assertTrue('p1' in config.cli_params['stack1'])
         self.assertTrue('p2' in config.cli_params['stack1'])
         self.assertTrue('v1' in config.cli_params['stack1'].values())
         self.assertTrue('v2' in config.cli_params['stack1'].values())
+
+    def test_raises_exception_for_cli_param_on_non_configured_stack(self):
+        with self.assertRaises(NoConfigException):
+            Config(cli_params=("stack1.p1=v1",),
+                        config_dict={'region': 'eu-west-1', 'stacks': {'stack2': {'template-url': 'foo.json'}}})
 
     def test_config_raises_exception_if_only_cli_params_given(self):
         with self.assertRaises(NoConfigException):


### PR DESCRIPTION
If you overwrite parameters using `-p`  and have an typo in the stack name the update won't use the parameter you provided without reporting an error.