### PR TITLE
better error message for unknown files

### DIFF
--- a/src/main/python/cfn_sphere/file_loader.py
+++ b/src/main/python/cfn_sphere/file_loader.py
@@ -38,6 +38,8 @@ class FileLoader(object):
         except Exception as e:
             raise TemplateErrorException("Could not load file from {0}: {1}".format(url, e))
 
+        raise TemplateErrorException("Template file must have either .yaml or .json extension")
+
     @staticmethod
     def _s3_get_file(url):
         s3 = S3()

--- a/src/main/python/cfn_sphere/file_loader.py
+++ b/src/main/python/cfn_sphere/file_loader.py
@@ -38,7 +38,7 @@ class FileLoader(object):
         except Exception as e:
             raise TemplateErrorException("Could not load file from {0}: {1}".format(url, e))
 
-        raise TemplateErrorException("Template file must have either .yaml or .json extension")
+        raise TemplateErrorException("Template file must have either .yml, .yaml or .json extension")
 
     @staticmethod
     def _s3_get_file(url):

--- a/src/unittest/python/file_loader_tests.py
+++ b/src/unittest/python/file_loader_tests.py
@@ -28,6 +28,10 @@ class FileLoaderTests(TestCase):
         with self.assertRaises(TemplateErrorException):
             FileLoader._fs_get_file('foo.json', 'baa')
 
+    def test_fs_get_file_raises_exception_on_unknown_filetype(self):
+        with self.assertRaises(TemplateErrorException):
+            FileLoader._fs_get_file('bla.blub', 'baa')
+
     @patch("cfn_sphere.file_loader.FileLoader._fs_get_file")
     def test_load_template_calls_fs_get_file_for_fs_url(self, mock):
         url = "/tmp/template.json"


### PR DESCRIPTION
If you don't give your templates the appropriate file name extension you end up with a very unhelpful error message. This change produces a nice message.

However, even better would be to determine the format by the contents not the name, so you could use any extension you like. e.g. The IDEA CloudFormation plugin creates JSON files with `.template` extensions.