### PR TITLE
feature: Equals method for StackConfig and Config class

### DIFF
--- a/src/main/python/cfn_sphere/stack_configuration/__init__.py
+++ b/src/main/python/cfn_sphere/stack_configuration/__init__.py
@@ -83,6 +83,21 @@ class Config(object):
         except Exception as e:
             raise NoConfigException("Could not read yaml file {0}: {1}".format(config_file, e))
 
+    def __eq__(self, other):
+        try:
+            stacks_equal = cmp(self.stacks, other.stacks) == 0
+
+            if (self.cli_params == other.cli_params
+                    and self.region == other.region
+                    and self.tags == other.tags
+                    and stacks_equal):
+                return True
+        except Exception:
+            return False
+
+    def __ne__(self, other):
+        return not self == other
+
 
 class StackConfig(object):
     def __init__(self, stack_config_dict, working_dir=None, default_tags={}):
@@ -97,3 +112,18 @@ class StackConfig(object):
             self.template_url = stack_config_dict['template-url']
         except KeyError as e:
             raise NoConfigException("Stack config needs a {0} key".format(e))
+
+    def __eq__(self, other):
+        try:
+            if (self.parameters == other.parameters
+                    and self.tags == other.tags
+                    and self.timeout == other.timeout
+                    and self.working_dir == other.working_dir):
+                return True
+        except Exception:
+            return False
+
+        return False
+
+    def __ne__(self, other):
+        return not self == other

--- a/src/main/python/cfn_sphere/stack_configuration/__init__.py
+++ b/src/main/python/cfn_sphere/stack_configuration/__init__.py
@@ -85,14 +85,14 @@ class Config(object):
 
     def __eq__(self, other):
         try:
-            stacks_equal = cmp(self.stacks, other.stacks) == 0
+            stacks_equal = self.stacks == other.stacks
 
             if (self.cli_params == other.cli_params
                     and self.region == other.region
                     and self.tags == other.tags
                     and stacks_equal):
                 return True
-        except Exception:
+        except AttributeError:
             return False
 
     def __ne__(self, other):
@@ -120,7 +120,7 @@ class StackConfig(object):
                     and self.timeout == other.timeout
                     and self.working_dir == other.working_dir):
                 return True
-        except Exception:
+        except AttributeError:
             return False
 
         return False

--- a/src/unittest/python/stack_configuration/config_tests.py
+++ b/src/unittest/python/stack_configuration/config_tests.py
@@ -128,24 +128,28 @@ class ConfigTests(TestCase):
         self.assertEquals(config_a_I, config_a_II)
 
     def test_equals_Config_region(self):
+        config_a_I = self.create_config_object()
         config_b_region = self.create_config_object()
         config_b_region.region = 'region b'
 
         self.assertNotEquals(config_a_I, config_b_region)
 
     def test_equals_Config_tags(self):
+        config_a_I = self.create_config_object()
         config_b_tags = self.create_config_object()
         config_b_tags.tags = {}
 
         self.assertNotEquals(config_a_I, config_b_tags)
 
     def test_equals_Config_cli_params(self):
+        config_a_I = self.create_config_object()
         config_b_cli_params = self.create_config_object()
         config_b_cli_params.cli_params = {}
 
         self.assertNotEquals(config_a_I, config_b_cli_params)
 
     def test_equals_Config_stacks(self):
+        config_a_I = self.create_config_object()
         config_b_cli_stacks = self.create_config_object()
         config_b_cli_stacks.stacks = {}
 


### PR DESCRIPTION
Add equals method for StackConfig and Config classes. This makes tests easier when using cfn-sphere as API as you not have to compare value per value.


Cheers

Niels