### PR TITLE
Fix #99: Throttling by CloudFormation

### DIFF
--- a/src/main/python/cfn_sphere/aws/cfn.py
+++ b/src/main/python/cfn_sphere/aws/cfn.py
@@ -105,8 +105,8 @@ class CloudFormation(object):
         """
         try:
             paginator = self.client.get_paginator('describe_stack_events')
-            return tuple(paginator.paginate(StackName=stack_name,
-                                            PaginationConfig={'MaxItems': 100}))[0]["StackEvents"]
+            pages = paginator.paginate(StackName=stack_name, PaginationConfig={'MaxItems': 100})
+            return iter(pages).next()["StackEvents"]
         except (BotoCoreError, ClientError) as e:
             raise CfnSphereBotoError(e)
 

--- a/src/main/python/cfn_sphere/aws/cfn.py
+++ b/src/main/python/cfn_sphere/aws/cfn.py
@@ -105,7 +105,8 @@ class CloudFormation(object):
         """
         try:
             paginator = self.client.get_paginator('describe_stack_events')
-            return tuple(paginator.paginate(StackName=stack_name))[0]["StackEvents"]
+            return tuple(paginator.paginate(StackName=stack_name,
+                                            PaginationConfig={'MaxItems': 100}))[0]["StackEvents"]
         except (BotoCoreError, ClientError) as e:
             raise CfnSphereBotoError(e)
 
@@ -376,6 +377,8 @@ class CloudFormation(object):
 
             events = self.get_stack_events(stack_name)
             events.reverse()
+
+            self.logger.debug("Got {0} events".format(len(events)))
 
             for event in events:
                 if event["EventId"] not in seen_event_ids:


### PR DESCRIPTION
The problem was increasing for long-living stacks that received regular updates. In this case retrieving events can easily yield a few megabytes of data. Simply using the paginator did not fix it because even then boto did several requests to retrieve *all* events. The only thing to stop boto from retrieving all events is to limit the result set by setting `{ MaxSize: 100 }`.

100 events should be enough, the same amount was returned by the old implementation because only the first chunk was returned. Even when thousands of elements were retrieved. =:-O