### PR TITLE
Additional stack config

### DIFF
--- a/build.py
+++ b/build.py
@@ -31,7 +31,7 @@ def set_properties(project):
     project.build_depends_on("moto")
     project.depends_on('six')
     project.depends_on("click")
-    project.depends_on("boto3")
+    project.depends_on("boto3>=1.4.1")
     project.depends_on("pyyaml")
     project.depends_on("networkx")
     project.depends_on('prettytable')

--- a/build.py
+++ b/build.py
@@ -31,7 +31,7 @@ def set_properties(project):
     project.build_depends_on("moto")
     project.depends_on('six')
     project.depends_on("click")
-    project.depends_on("boto3>=1.4.1")
+    project.depends_on("boto3", version=">=1.4.1")
     project.depends_on("pyyaml")
     project.depends_on("networkx")
     project.depends_on('prettytable')

--- a/src/main/python/cfn_sphere/__init__.py
+++ b/src/main/python/cfn_sphere/__init__.py
@@ -33,7 +33,10 @@ class StackActionHandler(object):
             template = FileLoader.get_cloudformation_template(stack_config.template_url,stack_config.working_dir)
             transformed_template = CloudFormationTemplateTransformer.transform_template(template)
 
-            stack_policy = FileLoader.get_yaml_or_json_file(stack_config.stack_policy_url, stack_config.working_dir)
+            if stack_config.stack_policy_url:
+                stack_policy = FileLoader.get_yaml_or_json_file(stack_config.stack_policy_url, stack_config.working_dir)
+            else:
+                stack_policy = None
 
             parameters = self.parameter_resolver.resolve_parameter_values(stack_name, stack_config)
             merged_parameters = self.parameter_resolver.update_parameters_with_cli_parameters(
@@ -45,7 +48,7 @@ class StackActionHandler(object):
 
             stack = CloudFormationStack(template=transformed_template,
                                         parameters=merged_parameters,
-                                        tags=self.config.tags,
+                                        tags=stack_config.tags,
                                         name=stack_name,
                                         region=self.config.region,
                                         timeout=stack_config.timeout,

--- a/src/main/python/cfn_sphere/__init__.py
+++ b/src/main/python/cfn_sphere/__init__.py
@@ -34,6 +34,7 @@ class StackActionHandler(object):
             transformed_template = CloudFormationTemplateTransformer.transform_template(template)
 
             if stack_config.stack_policy_url:
+                self.logger.info("Using stack policy from {0}".format(stack_config.stack_policy_url))
                 stack_policy = FileLoader.get_yaml_or_json_file(stack_config.stack_policy_url, stack_config.working_dir)
             else:
                 stack_policy = None

--- a/src/main/python/cfn_sphere/__init__.py
+++ b/src/main/python/cfn_sphere/__init__.py
@@ -30,10 +30,10 @@ class StackActionHandler(object):
         for stack_name in stack_processing_order:
             stack_config = self.config.stacks.get(stack_name)
 
-            template = FileLoader.get_cloudformation_template(stack_config.template_url,
-                                                              stack_config.working_dir)
-
+            template = FileLoader.get_cloudformation_template(stack_config.template_url,stack_config.working_dir)
             transformed_template = CloudFormationTemplateTransformer.transform_template(template)
+
+            stack_policy = FileLoader.get_yaml_or_json_file(stack_config.stack_policy_url, stack_config.working_dir)
 
             parameters = self.parameter_resolver.resolve_parameter_values(stack_name, stack_config)
             merged_parameters = self.parameter_resolver.update_parameters_with_cli_parameters(
@@ -48,7 +48,9 @@ class StackActionHandler(object):
                                         tags=self.config.tags,
                                         name=stack_name,
                                         region=self.config.region,
-                                        timeout=stack_config.timeout)
+                                        timeout=stack_config.timeout,
+                                        service_role=stack_config.service_role,
+                                        stack_policy=stack_policy)
 
             if stack_name in existing_stacks:
 
@@ -69,8 +71,10 @@ class StackActionHandler(object):
         self.logger.info("Will delete stacks in the following order: {0}".format(", ".join(stack_processing_order)))
 
         for stack_name in stack_processing_order:
+            stack_config = self.config.stacks.get(stack_name)
+
             if stack_name in existing_stacks:
-                stack = CloudFormationStack(None, None, stack_name, None, None)
+                stack = CloudFormationStack(None, None, stack_name, None, None, service_role=stack_config.service_role)
                 self.cfn.validate_stack_is_ready_for_action(stack)
                 self.cfn.delete_stack(stack)
             else:

--- a/src/main/python/cfn_sphere/aws/cfn.py
+++ b/src/main/python/cfn_sphere/aws/cfn.py
@@ -270,7 +270,7 @@ class CloudFormation(object):
         if stack.service_role:
             kwargs["RoleARN"] = stack.service_role
         if stack.stack_policy:
-            kwargs["StackPolicyBody"] = stack.stack_policy
+            kwargs["StackPolicyBody"] = json.dumps(stack.stack_policy)
 
         self.client.create_stack(**kwargs)
 
@@ -294,7 +294,7 @@ class CloudFormation(object):
         if stack.service_role:
             kwargs["RoleARN"] = stack.service_role
         if stack.stack_policy:
-            kwargs["StackPolicyBody"] = stack.stack_policy
+            kwargs["StackPolicyBody"] = json.dumps(stack.stack_policy)
 
         self.client.update_stack(**kwargs)
 

--- a/src/main/python/cfn_sphere/aws/cfn.py
+++ b/src/main/python/cfn_sphere/aws/cfn.py
@@ -258,7 +258,6 @@ class CloudFormation(object):
             "StackName": stack.name,
             "TemplateBody": stack.template.get_template_json(),
             "Parameters": stack.get_parameters_list(),
-            "TimeoutInMinutes": stack.timeout,
             "Capabilities": [
                 'CAPABILITY_IAM',
                 'CAPABILITY_NAMED_IAM'

--- a/src/main/python/cfn_sphere/aws/cfn.py
+++ b/src/main/python/cfn_sphere/aws/cfn.py
@@ -304,7 +304,14 @@ class CloudFormation(object):
         Delete cloudformation stack
         :param stack: cfn_sphere.aws.cfn.CloudFormationStack
         """
-        self.client.delete_stack(StackName=stack.name, RoleARN=stack.service_role)
+        kwargs = {
+            "StackName": stack.name
+        }
+
+        if stack.service_role:
+            kwargs["RoleARN"] = stack.service_role
+
+        self.client.delete_stack(**kwargs)
 
     def create_stack(self, stack):
         self.logger.debug("Creating stack: {0}".format(stack))

--- a/src/main/python/cfn_sphere/exceptions.py
+++ b/src/main/python/cfn_sphere/exceptions.py
@@ -25,7 +25,7 @@ class TemplateErrorException(CfnSphereException):
     pass
 
 
-class NoConfigException(CfnSphereException):
+class InvalidConfigException(CfnSphereException):
     pass
 
 

--- a/src/main/python/cfn_sphere/stack_configuration/__init__.py
+++ b/src/main/python/cfn_sphere/stack_configuration/__init__.py
@@ -9,6 +9,8 @@ from yaml.scanner import ScannerError
 from cfn_sphere.exceptions import InvalidConfigException, CfnSphereException
 from cfn_sphere.util import get_logger
 
+ALLOWED_CONFIG_KEYS = ["region", "stacks", "service-role", "stack-policy-url", "timeout", "tags"]
+
 
 class Config(object):
     def __init__(self, config_file=None, config_dict=None, cli_params=None):
@@ -23,19 +25,25 @@ class Config(object):
             raise InvalidConfigException("No config_file or valid config_dict provided")
 
         self.cli_params = self._parse_cli_parameters(cli_params)
-        self.region = config_dict.get('region')
+        self.region = config_dict.get("region")
 
-        self.default_service_role = config_dict.get('service-role')
-        self.default_stack_policy_url = config_dict.get('stack-policy-url')
-        self.default_timeout = config_dict.get('timeout', 600)
-        self.default_tags = config_dict.get('tags', {})
+        self.default_service_role = config_dict.get("service-role")
+        self.default_stack_policy_url = config_dict.get("stack-policy-url")
+        self.default_timeout = config_dict.get("timeout", 600)
+        self.default_tags = config_dict.get("tags", {})
         self.default_tags = self._add_git_remote_url_tag(self.default_tags, self.working_dir)
 
         self.stacks = self._parse_stack_configs(config_dict)
+        self._config_dict = config_dict
+
         self._validate()
 
     def _validate(self):
         try:
+            for key in self._config_dict.keys():
+                assert str(key).lower() in ALLOWED_CONFIG_KEYS, \
+                    "Invalid syntax, {0} is not allowed as top level config key".format(key)
+
             assert self.region, "Please specify region in config file"
             assert isinstance(self.region, str), "Region must be of type str, not {0}".format(type(self.region))
 
@@ -43,7 +51,7 @@ class Config(object):
             assert isinstance(self.stacks, dict), "stacks must be of type dict, not {0}".format(type(self.stacks))
 
             for cli_stack in self.cli_params.keys():
-                assert cli_stack in self.stacks.keys(), 'Stack "{0}" does not exist in config'.format(cli_stack)
+                assert cli_stack in self.stacks.keys(), "Stack '{0}' does not exist in config".format(cli_stack)
 
         except AssertionError as e:
             raise InvalidConfigException(e)
@@ -75,8 +83,8 @@ class Config(object):
     def _find_git_repo_root(self, tags, working_dir):
         try:
             repo = Repo(working_dir)
-            tags['config-git-repository'] = repo.remotes.origin.url
-            self.logger.info('Stack config located in git repository, adding tag "config-git-repository": "%s"'
+            tags["config-git-repository"] = repo.remotes.origin.url
+            self.logger.info("Stack config located in git repository, adding tag 'config-git-repository': '%s'"
                              % repo.remotes.origin.url)
             return tags
         except InvalidGitRepositoryError as e:
@@ -95,7 +103,7 @@ class Config(object):
         :return: dict(stack_name: StackConfig)
         """
         stacks_dict = {}
-        for key, value in config_dict.get('stacks', {}).items():
+        for key, value in config_dict.get("stacks", {}).items():
             try:
                 stacks_dict[key] = StackConfig(value,
                                                working_dir=self.working_dir,
@@ -120,8 +128,8 @@ class Config(object):
         if parameters:
             try:
                 for key_value_parameter_pair in parameters:
-                    stack_and_parameter_key, parameter_value = key_value_parameter_pair.split('=', 1)
-                    stack, parameter_key = stack_and_parameter_key.split('.', 1)
+                    stack_and_parameter_key, parameter_value = key_value_parameter_pair.split("=", 1)
+                    stack, parameter_key = stack_and_parameter_key.split(".", 1)
 
                     stack_parameter = {parameter_key.strip(): parameter_value.strip()}
                     param_dict[stack.strip()].update(stack_parameter)
@@ -134,7 +142,7 @@ class Config(object):
     @staticmethod
     def _read_config_file(config_file):
         try:
-            with open(config_file, 'r') as f:
+            with open(config_file, "r") as f:
                 config_dict = yaml.safe_load(f.read())
                 if not isinstance(config_dict, dict):
                     raise InvalidConfigException(
@@ -148,25 +156,35 @@ class Config(object):
 
 
 class StackConfig(object):
+    STACK_CONFIG_ALLOWED_CONFIG_KEYS = ["parameters", "template-url"] + ALLOWED_CONFIG_KEYS
+
     def __init__(self, stack_config_dict, working_dir=None, default_tags=None, default_timeout=600,
                  default_service_role=None, default_stack_policy_url=None):
 
+        if not stack_config_dict or not isinstance(stack_config_dict, dict):
+            raise InvalidConfigException("Stack configuration must not be empty")
+
         if default_tags is None:
             default_tags = {}
-        self.parameters = stack_config_dict.get('parameters', {})
+        self.parameters = stack_config_dict.get("parameters", {})
         self.tags = {}
         self.tags.update(default_tags)
-        self.tags.update(stack_config_dict.get('tags', {}))
-        self.service_role = stack_config_dict.get('service-role', default_service_role)
-        self.stack_policy_url = stack_config_dict.get('stack-policy-url', default_stack_policy_url)
-        self.timeout = stack_config_dict.get('timeout', default_timeout)
+        self.tags.update(stack_config_dict.get("tags", {}))
+        self.service_role = stack_config_dict.get("service-role", default_service_role)
+        self.stack_policy_url = stack_config_dict.get("stack-policy-url", default_stack_policy_url)
+        self.timeout = stack_config_dict.get("timeout", default_timeout)
         self.working_dir = working_dir
-        self.template_url = stack_config_dict.get('template-url')
+        self.template_url = stack_config_dict.get("template-url")
+        self._stack_config_dict = stack_config_dict
 
         self._validate()
 
     def _validate(self):
         try:
+            for key in self._stack_config_dict.keys():
+                assert str(key).lower() in self.STACK_CONFIG_ALLOWED_CONFIG_KEYS, \
+                    "Invalid syntax, {0} is not allowed as stack config key".format(key)
+
             assert self.template_url, "Stack config needs a template-url key"
             assert isinstance(self.template_url, str), \
                 "template-url must be of type str, not {0}".format(type(self.template_url))

--- a/src/main/python/cfn_sphere/util.py
+++ b/src/main/python/cfn_sphere/util.py
@@ -65,15 +65,21 @@ def get_pretty_parameters_string(stack):
 
 def get_pretty_stack_outputs(stack_outputs):
     table = PrettyTable(["Output", "Value"])
+    table_has_entries = False
 
     for output in stack_outputs:
+        table_has_entries = True
         table.add_row([output["OutputKey"], output["OutputValue"]])
 
-    return table.get_string(sortby="Output")
+    if table_has_entries:
+        return table.get_string(sortby="Output")
+    else:
+        return None
 
 
 def strip_string(string):
-    return string[:100]
+    return string[:100] + "..."
+
 
 def convert_json_to_yaml_string(data):
     if not data:

--- a/src/unittest/python/aws_tests/cfn_tests.py
+++ b/src/unittest/python/aws_tests/cfn_tests.py
@@ -203,8 +203,7 @@ class CloudFormationApiTests(TestCase):
             Parameters=[('a', 'b')],
             StackName='stack-name',
             Tags=[('any-tag', 'any-tag-value')],
-            TemplateBody={'key': 'value'},
-            TimeoutInMinutes=42,
+            TemplateBody={'key': 'value'}
         )
 
     @patch('cfn_sphere.aws.cfn.boto3.client')
@@ -232,7 +231,6 @@ class CloudFormationApiTests(TestCase):
             StackName='stack-name',
             Tags=[('any-tag', 'any-tag-value')],
             TemplateBody={'key': 'value'},
-            TimeoutInMinutes=42,
             RoleARN="arn:aws:iam::1234567890:role/my-role"
         )
 
@@ -261,7 +259,6 @@ class CloudFormationApiTests(TestCase):
             StackName='stack-name',
             Tags=[('any-tag', 'any-tag-value')],
             TemplateBody={'key': 'value'},
-            TimeoutInMinutes=42,
             StackPolicyBody='"{foo:baa}"'
         )
 

--- a/src/unittest/python/aws_tests/cfn_tests.py
+++ b/src/unittest/python/aws_tests/cfn_tests.py
@@ -262,7 +262,7 @@ class CloudFormationApiTests(TestCase):
             Tags=[('any-tag', 'any-tag-value')],
             TemplateBody={'key': 'value'},
             TimeoutInMinutes=42,
-            StackPolicyBody="{foo:baa}"
+            StackPolicyBody='"{foo:baa}"'
         )
 
     @patch('cfn_sphere.aws.cfn.boto3.client')
@@ -342,7 +342,7 @@ class CloudFormationApiTests(TestCase):
             StackName='stack-name',
             Tags=[('any-tag', 'any-tag-value')],
             TemplateBody={'key': 'value'},
-            StackPolicyBody='{foo:baa}'
+            StackPolicyBody='"{foo:baa}"'
         )
 
     @patch('cfn_sphere.aws.cfn.CloudFormation.get_stack')

--- a/src/unittest/python/aws_tests/cfn_tests.py
+++ b/src/unittest/python/aws_tests/cfn_tests.py
@@ -205,8 +205,64 @@ class CloudFormationApiTests(TestCase):
             Tags=[('any-tag', 'any-tag-value')],
             TemplateBody={'key': 'value'},
             TimeoutInMinutes=42,
-            StackPolicyBody=None,
-            RoleARN=None
+        )
+
+    @patch('cfn_sphere.aws.cfn.boto3.client')
+    @patch('cfn_sphere.aws.cfn.CloudFormation.wait_for_stack_action_to_complete')
+    def test_create_stack_calls_cloudformation_api_properly_with_service_role(self, _, cloudformation_mock):
+        stack = Mock(spec=CloudFormationStack)
+        stack.name = "stack-name"
+        stack.get_parameters_list.return_value = [('a', 'b')]
+        stack.get_tags_list.return_value = [('any-tag', 'any-tag-value')]
+        stack.parameters = {}
+        stack.template = Mock(spec=CloudFormationTemplate)
+        stack.template.name = "template-name"
+        stack.template.get_template_json.return_value = {'key': 'value'}
+        stack.service_role = "arn:aws:iam::1234567890:role/my-role"
+        stack.stack_policy = None
+        stack.timeout = 42
+
+        cfn = CloudFormation()
+        cfn.create_stack(stack)
+
+        cloudformation_mock.return_value.create_stack.assert_called_once_with(
+            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+            OnFailure='ROLLBACK',
+            Parameters=[('a', 'b')],
+            StackName='stack-name',
+            Tags=[('any-tag', 'any-tag-value')],
+            TemplateBody={'key': 'value'},
+            TimeoutInMinutes=42,
+            RoleARN="arn:aws:iam::1234567890:role/my-role"
+        )
+
+    @patch('cfn_sphere.aws.cfn.boto3.client')
+    @patch('cfn_sphere.aws.cfn.CloudFormation.wait_for_stack_action_to_complete')
+    def test_create_stack_calls_cloudformation_api_properly_with_stack_policy(self, _, cloudformation_mock):
+        stack = Mock(spec=CloudFormationStack)
+        stack.name = "stack-name"
+        stack.get_parameters_list.return_value = [('a', 'b')]
+        stack.get_tags_list.return_value = [('any-tag', 'any-tag-value')]
+        stack.parameters = {}
+        stack.template = Mock(spec=CloudFormationTemplate)
+        stack.template.name = "template-name"
+        stack.template.get_template_json.return_value = {'key': 'value'}
+        stack.service_role = None
+        stack.stack_policy = "{foo:baa}"
+        stack.timeout = 42
+
+        cfn = CloudFormation()
+        cfn.create_stack(stack)
+
+        cloudformation_mock.return_value.create_stack.assert_called_once_with(
+            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+            OnFailure='ROLLBACK',
+            Parameters=[('a', 'b')],
+            StackName='stack-name',
+            Tags=[('any-tag', 'any-tag-value')],
+            TemplateBody={'key': 'value'},
+            TimeoutInMinutes=42,
+            StackPolicyBody="{foo:baa}"
         )
 
     @patch('cfn_sphere.aws.cfn.boto3.client')
@@ -232,9 +288,61 @@ class CloudFormationApiTests(TestCase):
             Parameters=[('a', 'b')],
             StackName='stack-name',
             Tags=[('any-tag', 'any-tag-value')],
+            TemplateBody={'key': 'value'}
+        )
+
+    @patch('cfn_sphere.aws.cfn.boto3.client')
+    @patch('cfn_sphere.aws.cfn.CloudFormation.wait_for_stack_action_to_complete')
+    def test_update_stack_calls_cloudformation_api_properly_with_service_role(self, _, cloudformation_mock):
+        stack = Mock(spec=CloudFormationStack)
+        stack.name = "stack-name"
+        stack.get_parameters_list.return_value = [('a', 'b')]
+        stack.get_tags_list.return_value = [('any-tag', 'any-tag-value')]
+        stack.parameters = {}
+        stack.template = Mock(spec=CloudFormationTemplate)
+        stack.template.name = "template-name"
+        stack.template.get_template_json.return_value = {'key': 'value'}
+        stack.service_role = "arn:aws:iam::1234567890:role/my-role"
+        stack.stack_policy = None
+        stack.timeout = 42
+
+        cfn = CloudFormation()
+        cfn.update_stack(stack)
+
+        cloudformation_mock.return_value.update_stack.assert_called_once_with(
+            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+            Parameters=[('a', 'b')],
+            StackName='stack-name',
+            Tags=[('any-tag', 'any-tag-value')],
             TemplateBody={'key': 'value'},
-            StackPolicyBody=None,
-            RoleARN=None
+            RoleARN='arn:aws:iam::1234567890:role/my-role'
+        )
+
+    @patch('cfn_sphere.aws.cfn.boto3.client')
+    @patch('cfn_sphere.aws.cfn.CloudFormation.wait_for_stack_action_to_complete')
+    def test_update_stack_calls_cloudformation_api_properly_with_stack_policy(self, _, cloudformation_mock):
+        stack = Mock(spec=CloudFormationStack)
+        stack.name = "stack-name"
+        stack.get_parameters_list.return_value = [('a', 'b')]
+        stack.get_tags_list.return_value = [('any-tag', 'any-tag-value')]
+        stack.parameters = {}
+        stack.template = Mock(spec=CloudFormationTemplate)
+        stack.template.name = "template-name"
+        stack.template.get_template_json.return_value = {'key': 'value'}
+        stack.service_role = None
+        stack.stack_policy = "{foo:baa}"
+        stack.timeout = 42
+
+        cfn = CloudFormation()
+        cfn.update_stack(stack)
+
+        cloudformation_mock.return_value.update_stack.assert_called_once_with(
+            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+            Parameters=[('a', 'b')],
+            StackName='stack-name',
+            Tags=[('any-tag', 'any-tag-value')],
+            TemplateBody={'key': 'value'},
+            StackPolicyBody='{foo:baa}'
         )
 
     @patch('cfn_sphere.aws.cfn.CloudFormation.get_stack')

--- a/src/unittest/python/aws_tests/cfn_tests.py
+++ b/src/unittest/python/aws_tests/cfn_tests.py
@@ -190,6 +190,8 @@ class CloudFormationApiTests(TestCase):
         stack.template = Mock(spec=CloudFormationTemplate)
         stack.template.name = "template-name"
         stack.template.get_template_json.return_value = {'key': 'value'}
+        stack.service_role = None
+        stack.stack_policy = None
         stack.timeout = 42
 
         cfn = CloudFormation()
@@ -202,7 +204,10 @@ class CloudFormationApiTests(TestCase):
             StackName='stack-name',
             Tags=[('any-tag', 'any-tag-value')],
             TemplateBody={'key': 'value'},
-            TimeoutInMinutes=42)
+            TimeoutInMinutes=42,
+            StackPolicyBody=None,
+            RoleARN=None
+        )
 
     @patch('cfn_sphere.aws.cfn.boto3.client')
     @patch('cfn_sphere.aws.cfn.CloudFormation.wait_for_stack_action_to_complete')
@@ -215,6 +220,8 @@ class CloudFormationApiTests(TestCase):
         stack.template = Mock(spec=CloudFormationTemplate)
         stack.template.name = "template-name"
         stack.template.get_template_json.return_value = {'key': 'value'}
+        stack.service_role = None
+        stack.stack_policy = None
         stack.timeout = 42
 
         cfn = CloudFormation()
@@ -225,7 +232,10 @@ class CloudFormationApiTests(TestCase):
             Parameters=[('a', 'b')],
             StackName='stack-name',
             Tags=[('any-tag', 'any-tag-value')],
-            TemplateBody={'key': 'value'})
+            TemplateBody={'key': 'value'},
+            StackPolicyBody=None,
+            RoleARN=None
+        )
 
     @patch('cfn_sphere.aws.cfn.CloudFormation.get_stack')
     def test_validate_stack_is_ready_for_action_raises_exception_on_unknown_stack_state(self, get_stack_mock):
@@ -239,7 +249,6 @@ class CloudFormationApiTests(TestCase):
         cfn = CloudFormation()
         with self.assertRaises(CfnStackActionFailedException):
             cfn.validate_stack_is_ready_for_action(stack)
-
 
     @patch('cfn_sphere.aws.cfn.CloudFormation.get_stack')
     def test_validate_stack_is_ready_for_action_raises_exception_on_update_in_progress(self, get_stack_mock):

--- a/src/unittest/python/stack_action_handler_tests.py
+++ b/src/unittest/python/stack_action_handler_tests.py
@@ -74,7 +74,7 @@ class StackActionHandlerTests(TestCase):
         stack_a = CloudFormationStack('', [], 'a', '')
         stack_c = CloudFormationStack('', [], 'c', '')
 
-        def stack_side_effect(*args):
+        def stack_side_effect(*args, **kwargs):
             if args[2] == 'a':
                 return stack_a
             if args[2] == 'c':
@@ -108,7 +108,7 @@ class StackActionHandlerTests(TestCase):
         stack_a = CloudFormationStack('', [], 'a', '')
         stack_c = CloudFormationStack('', [], 'c', '')
 
-        def stack_side_effect(*args):
+        def stack_side_effect(*args, **kwargs):
             if args[2] == 'a':
                 return stack_a
             if args[2] == 'c':

--- a/src/unittest/python/stack_configuration_tests/config_tests.py
+++ b/src/unittest/python/stack_configuration_tests/config_tests.py
@@ -12,7 +12,7 @@ from mock import patch, Mock
 from git.exc import InvalidGitRepositoryError
 
 from cfn_sphere.exceptions import CfnSphereException
-from cfn_sphere.stack_configuration import Config, StackConfig, NoConfigException
+from cfn_sphere.stack_configuration import Config, StackConfig, InvalidConfigException
 
 
 class ConfigTests(TestCase):
@@ -75,11 +75,11 @@ class ConfigTests(TestCase):
         self.assertEqual(99, config.stacks['any-stack'].timeout)
 
     def test_raises_exception_if_no_region_key(self):
-        with self.assertRaises(NoConfigException):
+        with self.assertRaises(InvalidConfigException):
             Config(config_dict={'foo': '', 'stacks': {'any-stack': {'template': 'foo.json'}}})
 
     def test_raises_exception_if_no_stacks_key(self):
-        with self.assertRaises(NoConfigException):
+        with self.assertRaises(InvalidConfigException):
             Config(config_dict={'region': 'eu-west-1'})
 
     def test_properties_parsing_cli_params(self):
@@ -91,12 +91,12 @@ class ConfigTests(TestCase):
         self.assertTrue('v2' in config.cli_params['stack1'].values())
 
     def test_raises_exception_for_cli_param_on_non_configured_stack(self):
-        with self.assertRaises(NoConfigException):
+        with self.assertRaises(InvalidConfigException):
             Config(cli_params=("stack1.p1=v1",),
                    config_dict={'region': 'eu-west-1', 'stacks': {'stack2': {'template-url': 'foo.json'}}})
 
     def test_config_raises_exception_if_only_cli_params_given(self):
-        with self.assertRaises(NoConfigException):
+        with self.assertRaises(InvalidConfigException):
             Config(cli_params="foo")
 
     def test_parse_cli_parameters_throws_exception_on_invalid_syntax(self):

--- a/src/unittest/python/util_tests.py
+++ b/src/unittest/python/util_tests.py
@@ -190,9 +190,11 @@ class StackConfigTests(TestCase):
     def test_strip_string_strips_string(self):
         s = "sfsdklgashgslkadghkafhgaknkbndkjfbnwurtqwhgsdnkshGLSAKGKLDJFHGSKDLGFLDFGKSDFLGKHAsdjdghskjdhsdcxbvwerA323"
         result = util.strip_string(s)
-        self.assertTrue(len(result) == 100)
+        self.assertEqual(
+            "sfsdklgashgslkadghkafhgaknkbndkjfbnwurtqwhgsdnkshGLSAKGKLDJFHGSKDLGFLDFGKSDFLGKHAsdjdghskjdhsdcxbvwe...",
+            result)
 
-    def test_strip_string_doesnt_string_short_strings(self):
+    def test_strip_string_doesnt_strip_short_strings(self):
         s = "my-short-string"
         result = util.strip_string(s)
-        self.assertEqual("my-short-string", result)
+        self.assertEqual("my-short-string...", result)


### PR DESCRIPTION
Support configuration of service iam roles (used by cfn to manage stacks and resources) and stack policies both on a stack configuration level for all it's stacks and also per stack. Refactor other configuration properties like tags and timeout to behave equally.