### PR TITLE
Allow --parameter to be set on all stacks. 

### DIFF
--- a/src/main/python/cfn_sphere/stack_configuration/__init__.py
+++ b/src/main/python/cfn_sphere/stack_configuration/__init__.py
@@ -129,7 +129,11 @@ class Config(object):
             try:
                 for key_value_parameter_pair in parameters:
                     stack_and_parameter_key, parameter_value = key_value_parameter_pair.split("=", 1)
-                    stack, parameter_key = stack_and_parameter_key.split(".", 1)
+                    if '.' in stack_and_parameter_key:
+                        stack, parameter_key = stack_and_parameter_key.split(".", 1)
+                    else:
+                        stack = None
+                        parameter_key = stack_and_parameter_key
 
                     stack_parameter = {parameter_key.strip(): parameter_value.strip()}
                     param_dict[stack.strip()].update(stack_parameter)

--- a/src/main/python/cfn_sphere/stack_configuration/__init__.py
+++ b/src/main/python/cfn_sphere/stack_configuration/__init__.py
@@ -11,6 +11,7 @@ from cfn_sphere.util import get_logger
 
 ALLOWED_CONFIG_KEYS = ["region", "stacks", "service-role", "stack-policy-url", "timeout", "tags"]
 
+PARAMETERS_FOR_ALL_STACKS = "*"
 
 class Config(object):
     def __init__(self, config_file=None, config_dict=None, cli_params=None):
@@ -132,7 +133,7 @@ class Config(object):
                     if '.' in stack_and_parameter_key:
                         stack, parameter_key = stack_and_parameter_key.split(".", 1)
                     else:
-                        stack = None
+                        stack = PARAMETERS_FOR_ALL_STACKS
                         parameter_key = stack_and_parameter_key
 
                     stack_parameter = {parameter_key.strip(): parameter_value.strip()}

--- a/src/main/python/cfn_sphere/stack_configuration/parameter_resolver.py
+++ b/src/main/python/cfn_sphere/stack_configuration/parameter_resolver.py
@@ -139,7 +139,8 @@ class ParameterResolver(object):
 
         """
         if stack_name in cli_parameters.keys():
-            for new_key, new_value in cli_parameters[stack_name].items():
-                parameters[new_key] = new_value
+            parameters.update(cli_parameters[stack_name])
+        if None in cli_parameters:
+            parameters.update(cli_parameters[None])
 
         return parameters

--- a/src/main/python/cfn_sphere/stack_configuration/parameter_resolver.py
+++ b/src/main/python/cfn_sphere/stack_configuration/parameter_resolver.py
@@ -8,6 +8,7 @@ from cfn_sphere.exceptions import CfnSphereException
 from cfn_sphere.stack_configuration.dependency_resolver import DependencyResolver
 from cfn_sphere.util import get_logger
 
+from cfn_sphere.stack_configuration import PARAMETERS_FOR_ALL_STACKS
 
 class ParameterResolver(object):
     """
@@ -138,9 +139,10 @@ class ParameterResolver(object):
         :return: dict
 
         """
+        if PARAMETERS_FOR_ALL_STACKS in cli_parameters:
+            parameters.update(cli_parameters[PARAMETERS_FOR_ALL_STACKS])
+
         if stack_name in cli_parameters.keys():
             parameters.update(cli_parameters[stack_name])
-        if None in cli_parameters:
-            parameters.update(cli_parameters[None])
 
         return parameters

--- a/src/unittest/python/stack_action_handler_tests.py
+++ b/src/unittest/python/stack_action_handler_tests.py
@@ -9,39 +9,9 @@ import six
 
 from cfn_sphere import StackActionHandler
 from cfn_sphere.aws.cfn import CloudFormationStack
-from cfn_sphere.stack_configuration import PARAMETERS_FOR_ALL_STACKS
 
 
 class StackActionHandlerTests(TestCase):
-    @patch('cfn_sphere.stack_configuration.Config')
-    @patch('cfn_sphere.CloudFormation')
-    @patch('cfn_sphere.stack_configuration.parameter_resolver.CloudFormation')
-    @patch('cfn_sphere.DependencyResolver')
-    @patch('cfn_sphere.FileLoader')
-    @patch('cfn_sphere.CloudFormationStack')
-    @patch('cfn_sphere.CustomResourceHandler')
-    def test_merge_parameters_for_all_stacks(self,
-                                             custom_resource_mock,
-                                             stack_mock,
-                                             template_loader_mock,
-                                             dependency_resolver_mock,
-                                             cfn_mock,
-                                             resolver_cfn_mock,
-                                             config_mock):
-        # Given
-        dependency_resolver_mock.return_value.get_stack_order.return_value = ['a']
-        cfn_mock.return_value.get_stack_names.return_value = []
-        config_mock.return_value.cli_params.return_value = {PARAMETERS_FOR_ALL_STACKS: {'p1': 'v1'},
-                                                            "stack2": {"p2": "v2"}
-                                                            }
-
-        # When
-        handler = StackActionHandler(config_mock)
-        handler.create_or_update_stacks()
-
-        # Then
-        stack_mock.assert_called_once_with(parameters={'p1': 'v1', "p2": "v23"})
-
     @patch('cfn_sphere.stack_configuration.Config')
     @patch('cfn_sphere.CloudFormation')
     @patch('cfn_sphere.ParameterResolver')

--- a/src/unittest/python/stack_action_handler_tests.py
+++ b/src/unittest/python/stack_action_handler_tests.py
@@ -9,9 +9,39 @@ import six
 
 from cfn_sphere import StackActionHandler
 from cfn_sphere.aws.cfn import CloudFormationStack
+from cfn_sphere.stack_configuration import PARAMETERS_FOR_ALL_STACKS
 
 
 class StackActionHandlerTests(TestCase):
+    @patch('cfn_sphere.stack_configuration.Config')
+    @patch('cfn_sphere.CloudFormation')
+    @patch('cfn_sphere.stack_configuration.parameter_resolver.CloudFormation')
+    @patch('cfn_sphere.DependencyResolver')
+    @patch('cfn_sphere.FileLoader')
+    @patch('cfn_sphere.CloudFormationStack')
+    @patch('cfn_sphere.CustomResourceHandler')
+    def test_merge_parameters_for_all_stacks(self,
+                                             custom_resource_mock,
+                                             stack_mock,
+                                             template_loader_mock,
+                                             dependency_resolver_mock,
+                                             cfn_mock,
+                                             resolver_cfn_mock,
+                                             config_mock):
+        # Given
+        dependency_resolver_mock.return_value.get_stack_order.return_value = ['a']
+        cfn_mock.return_value.get_stack_names.return_value = []
+        config_mock.return_value.cli_params.return_value = {PARAMETERS_FOR_ALL_STACKS: {'p1': 'v1'},
+                                                            "stack2": {"p2": "v2"}
+                                                            }
+
+        # When
+        handler = StackActionHandler(config_mock)
+        handler.create_or_update_stacks()
+
+        # Then
+        stack_mock.assert_called_once_with(parameters={'p1': 'v1', "p2": "v23"})
+
     @patch('cfn_sphere.stack_configuration.Config')
     @patch('cfn_sphere.CloudFormation')
     @patch('cfn_sphere.ParameterResolver')

--- a/src/unittest/python/stack_configuration_tests/config_tests.py
+++ b/src/unittest/python/stack_configuration_tests/config_tests.py
@@ -12,7 +12,7 @@ from mock import patch, Mock
 from git.exc import InvalidGitRepositoryError
 
 from cfn_sphere.exceptions import CfnSphereException
-from cfn_sphere.stack_configuration import Config, StackConfig, InvalidConfigException
+from cfn_sphere.stack_configuration import Config, StackConfig, InvalidConfigException, PARAMETERS_FOR_ALL_STACKS
 
 
 class ConfigTests(TestCase):
@@ -246,6 +246,10 @@ class ConfigTests(TestCase):
         self.assertDictEqual({'stack1': {'p1': '1,2,3'}},
                              Config._parse_cli_parameters(("stack1.p1=1,2,3",)))
 
+    def test_parse_cli_parameters_accepts_all_stack_parameters(self):
+        self.assertDictEqual({PARAMETERS_FOR_ALL_STACKS: {'p1': '1,2,3'}, "stack2": {"p1": "v1"}},
+                             Config._parse_cli_parameters(("p1=1,2,3", "stack2.p1=v1 ")))
+
     def test_equals_Config(self):
         config_a_I = self.create_config_object()
 
@@ -285,8 +289,6 @@ class ConfigTests(TestCase):
         self.assertNotEquals(config_a_I, config_b_cli_stacks)
 
     def test_equals_StackConfig(self):
-        self.stack_config_a = self.create_stack_config()
-
         self.assertEquals(self.stack_config_a == self.stack_config_a, True)
         self.assertNotEquals(self.stack_config_a, 'any string')
 

--- a/src/unittest/python/stack_configuration_tests/parameter_resolver_tests.py
+++ b/src/unittest/python/stack_configuration_tests/parameter_resolver_tests.py
@@ -8,6 +8,8 @@ except ImportError:
 from cfn_sphere.exceptions import CfnSphereException, CfnSphereBotoError
 from cfn_sphere.stack_configuration.parameter_resolver import ParameterResolver
 
+from cfn_sphere.stack_configuration import PARAMETERS_FOR_ALL_STACKS
+
 
 class ParameterResolverTests(TestCase):
     def setUp(self):
@@ -187,6 +189,13 @@ class ParameterResolverTests(TestCase):
         result = ParameterResolver().update_parameters_with_cli_parameters(
             parameters={'foo': "foo"}, cli_parameters={'stack1': {'foo': 'foobar'}}, stack_name='stack2')
         self.assertEqual({'foo': 'foo'}, result)
+
+    def test_update_parameters_with_cli_parameters_adds_all_stack_parameters(self):
+        result = ParameterResolver().update_parameters_with_cli_parameters(
+            parameters={'foo': "foo"},
+            cli_parameters={PARAMETERS_FOR_ALL_STACKS: {'foo': 'foobar'}},
+            stack_name='stack2')
+        self.assertEqual({'foo': 'foobar'}, result)
 
     @patch('cfn_sphere.stack_configuration.parameter_resolver.FileLoader.get_file')
     def test_resolve_value_from_file(self, get_file_mock):


### PR DESCRIPTION
(Or omit stack name when there is only one.)

We need this especially since stack name is dynamic: we create several stacks from the same stacks-file.

DO NOT MERGE: tests are still missing.

Would you accept this (possibly replacing None with a well-named constant) or should we pass a separate dict of all_stack_parameters through stack_configuration.Config?
