### PR TITLE
add support for SSM parameters

### DIFF
--- a/build.py
+++ b/build.py
@@ -19,7 +19,7 @@ description = "cfn-sphere - A CLI tool intended to simplify AWS CloudFormation h
 license = 'APACHE LICENSE, VERSION 2.0'
 summary = 'cfn-sphere AWS CloudFormation management cli'
 url = 'https://github.com/cfn-sphere/cfn-sphere'
-version = '1.0.2'
+version = '1.0.3'
 
 default_task = ['clean', 'analyze', 'package']
 

--- a/src/integrationtest/resources/stacks.yml
+++ b/src/integrationtest/resources/stacks.yml
@@ -19,3 +19,5 @@ stacks:
       appVersion: "|keepOrUse|1"
       kmsEncryptedValue: "Place |kms|<ciphertext> value here to test decryption"
       textFileParameter: "|File|my-text-file-parameter.txt"
+      ssmPlainValue: "|ssm|/test-cfn-sphere/plain_parameter"
+      ssmEncryptedValue: "|ssm|/test-cfn-sphere/encrypted_parameter"

--- a/src/integrationtest/resources/templates/instances.yml
+++ b/src/integrationtest/resources/templates/instances.yml
@@ -16,6 +16,12 @@ Parameters:
   kmsEncryptedValue:
     Description: "A string encrypted at rest with kms to be decrypted by cfn-sphere before handing it over to cfn"
     Type: "String"
+  ssmPlainValue:
+    Description: "A stringwith ssm to be loaded by cfn-sphere before handling it over to cfn"
+    Type: "String"
+  ssmEncryptedValue:
+    Description: "A string encrypted at rest with ssm to be decrypted by cfn-sphere before handling it over to cfn"
+    Type: "String"
   textFileParameter:
     Description: "A parameter to be filled by a text file with |File|my-file.txt"
     Type: "String"
@@ -120,3 +126,5 @@ Resources:
                 b: !Ref someParameterB
                 c: "foo"
         kms_encrypted_value: "|Ref|kmsEncryptedValue"
+        ssm_plain_value: "|Ref|ssmPlainValue"
+        ssm_encrypted_value: "|Ref|ssmEncryptedValue"

--- a/src/main/python/cfn_sphere/aws/ssm.py
+++ b/src/main/python/cfn_sphere/aws/ssm.py
@@ -1,0 +1,20 @@
+import boto3
+from boto3.exceptions import Boto3Error
+from botocore.exceptions import ClientError
+from cfn_sphere.exceptions import CfnSphereBotoError, CfnSphereException
+
+class SSM(object):
+    
+    def __init__(self, region='eu-west-1'):
+        self.client = boto3.client('ssm', region_name=region)
+
+    def get_parameter(self, name, with_decryption=True):
+        try:
+            return self.client.get_parameter(Name=name, WithDecryption=with_decryption)['Parameter']['Value']
+        except (Boto3Error, ClientError) as e:
+            raise CfnSphereBotoError(e)
+
+if __name__ == "__main__":
+    ssm_client = SSM()
+    a = ssm_client.get_parameter('/tuv-blk/config.edn/database/blk-tuv-db-auroradbcluster/blk_master_cdc', True)
+    print(a)

--- a/src/unittest/python/aws_tests/ssm_tests.py
+++ b/src/unittest/python/aws_tests/ssm_tests.py
@@ -1,0 +1,17 @@
+try:
+    from unittest2 import TestCase
+    from mock import patch
+except ImportError:
+    from unittest import TestCase
+    from mock import patch
+
+from cfn_sphere.aws.ssm import SSM
+
+
+class SSMTests(TestCase):
+    @patch('cfn_sphere.aws.ssm.boto3.client')
+    def test_decrypt_value(self, boto_mock):
+        boto_mock.return_value.get_parameter.return_value = {'Parameter': { 'Value': 'decryptedValue'} }
+
+        self.assertEqual('decryptedValue', SSM().get_parameter('/test'))
+        boto_mock.return_value.get_parameter.assert_called_once_with(Name='/test', WithDecryption=True)


### PR DESCRIPTION
Hi,

We would love to be able to retrieve SSM parameters in our CloudFormation stacks. Currently CloudFormation does not support yet SSM parameter with encryption, what makes this feature really useful.