### PR TITLE
version 5.1 changed behaviour. make it compatible for both variants

### DIFF
--- a/src/main/python/cfn_sphere/file_loader.py
+++ b/src/main/python/cfn_sphere/file_loader.py
@@ -82,8 +82,12 @@ class FileLoader(object):
             elif url.lower().endswith(".template"):
                 return json.loads(file_content, encoding='utf-8')
             elif url.lower().endswith(".yml") or url.lower().endswith(".yaml"):
-                yaml.add_multi_constructor(u"", cls.handle_yaml_constructors)
-                return yaml.load(file_content)
+                if hasattr(yaml, 'FullLoader'):
+                    loader = yaml.FullLoader
+                else:
+                    loader = yaml.Loader
+                yaml.add_multi_constructor(u"", cls.handle_yaml_constructors, Loader=loader)
+                return yaml.load(file_content, Loader=loader)
             else:
                 raise CfnSphereException(
                     "Invalid suffix, use [json|template|yml|yaml]")

--- a/src/unittest/python/file_loader_tests.py
+++ b/src/unittest/python/file_loader_tests.py
@@ -78,7 +78,12 @@ class FileLoaderTests(TestCase):
         get_file_mock.return_value = get_file_return_value
 
         FileLoader.get_yaml_or_json_file('foo.yaml', 'baa')
-        yaml_mock.load.assert_called_once_with(get_file_return_value)
+        if hasattr(yaml_mock, 'FullLoader'):
+            loader = yaml_mock.FullLoader
+        else:
+            loader = yaml_mock.Loader
+
+        yaml_mock.load.assert_called_once_with(get_file_return_value, Loader=loader)
 
     @patch("cfn_sphere.file_loader.yaml")
     @patch("cfn_sphere.file_loader.FileLoader.get_file")
@@ -87,7 +92,12 @@ class FileLoaderTests(TestCase):
         get_file_mock.return_value = get_file_return_value
 
         FileLoader.get_yaml_or_json_file('foo.yml', 'baa')
-        yaml_mock.load.assert_called_once_with(get_file_return_value)
+        if hasattr(yaml_mock, 'FullLoader'):
+            loader = yaml_mock.FullLoader
+        else:
+            loader = yaml_mock.Loader
+
+        yaml_mock.load.assert_called_once_with(get_file_return_value, Loader=loader)
 
     @patch("cfn_sphere.file_loader.FileLoader.get_file")
     def test_get_yaml_or_json_file_raises_exception_invalid_file_extension(self, _):


### PR DESCRIPTION
version 5.1 of PyYAML changed behaviour. make it compatible for both variants