### PR TITLE
Locked click dependency to 6.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target
 *.pyc
 *.pyo
 /venv
+.venv/

--- a/build.py
+++ b/build.py
@@ -30,7 +30,7 @@ def set_properties(project):
     project.build_depends_on("mock")
     project.build_depends_on("moto")
     project.depends_on('six')
-    project.depends_on("click")
+    project.depends_on("click", version="<7.0.0")
     project.depends_on("boto3", version=">=1.4.1")
     project.depends_on("pyyaml")
     project.depends_on("networkx")


### PR DESCRIPTION
Click 7.0 changed behaviour by transforming commands using underscore to dashes. So `render_template` becomes `render-template`.

That by itself is not a problem. Unfortunately, if you also have aws-sam-cli installed, it requires click 6.7. This can cause issues with people using both tools at the same time.

It can also cause confusing on a team with some people having the command line with underscores and some with dashes.

Here is the change on click: https://github.com/pallets/click/commit/5d1df0e042b2f8b0dee8f6dd9ce74edce331a950